### PR TITLE
feat: added contact_changed event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -198,6 +198,12 @@ declare namespace WAWebJS {
             notification: GroupNotification
         ) => void): this
 
+        /** Emitted when a contact changed their phone number. */
+        on(event: 'contact_changed', listener: (
+            /** Message with more information about the action. */
+            message: Message
+        ) => void): this
+
         /** Emitted when media has been uploaded for a message sent by the client */
         on(event: 'media_uploaded', listener: (
             /** The message with media that was uploaded */
@@ -498,6 +504,7 @@ declare namespace WAWebJS {
         MESSAGE_REVOKED_ME = 'message_revoke_me',
         MESSAGE_ACK = 'message_ack',
         MEDIA_UPLOADED = 'media_uploaded',
+        CONTACT_CHANGED = 'contact_changed',
         GROUP_JOIN = 'group_join',
         GROUP_LEAVE = 'group_leave',
         GROUP_UPDATE = 'group_update',

--- a/src/Client.js
+++ b/src/Client.js
@@ -376,6 +376,20 @@ class Client extends EventEmitter {
                 last_message = msg;
             }
 
+            if (msg.type === 'notification_template') {
+                const message = new Message(this, msg);
+                if (msg.subtype === 'change_number') {
+                    /**
+                     * Emitted when a contact changed their phone number.
+                     * @event Client#contact_changed
+                     * @param {Message} message Message with more information about the action.
+                     * The event notification is shown in private chats.
+                     * Note that GroupNotification object with such a subtype does not provide sufficient information about the action, so a Message object is used.
+                     */
+                    this.emit(Events.CONTACT_CHANGED, message);
+                }
+            }
+
         });
 
         await page.exposeFunction('onRemoveMessageEvent', (msg) => {

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -43,6 +43,7 @@ exports.Events = {
     MESSAGE_ACK: 'message_ack',
     MESSAGE_REACTION: 'message_reaction',
     MEDIA_UPLOADED: 'media_uploaded',
+    CONTACT_CHANGED: 'contact_changed',
     GROUP_JOIN: 'group_join',
     GROUP_LEAVE: 'group_leave',
     GROUP_UPDATE: 'group_update',


### PR DESCRIPTION
## Description
PR adds `contact_changed` event.
The event is emitted when a **contact** changes their phone number.
After a contact changes their phone number, their id is also going to change.

The notification the event belongs to can be seen **in a private chat**:
![2](https://user-images.githubusercontent.com/93551621/220492730-5024ebf0-47a3-40f0-aaee-94c51a0d6ba3.png)

The pop-up message that is shown when clicking on a notification:
![3](https://user-images.githubusercontent.com/93551621/220492489-2d199c34-3f4b-47e3-84a0-d10917f814ec.png)


## Usage Example
```javascript
client.on('contact_changed', (notification) => {
    /**
     * {@link notification.templateParams} is an array of two user's ids:
     * the old and a new one, stored in increased order.
     * 
     * {@link notification.from} is a currentUserId that has a Chat with a user,
     * which phone number was changed, e.g.: 'ZZZZZZZZZ@c.us.
     */
    /** The userId (the new one, e.g.: 'YYYYYYYYY@c.us'), the current user has a Chat with. */
    const newId = notification.to;
    /** A userId (an old one) that was changed, e.g.: 'XXXXXXXXX@c.us'. */
    const oldId = notification.templateParams.find(id => id !== newId);
    /** Date the event was emitted at. */
    const eventTime = (new Date(notification.timestamp * 1000)).toLocaleString();

    console.log(`The user ${oldId} changed their phone number at ${eventTime}. ` +
        `Their new id is ${newId}.`)
});
```

## Types of Changes
- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (index.d.ts).