### PR TITLE
feat: added group_participant_changed event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -198,6 +198,12 @@ declare namespace WAWebJS {
             notification: GroupNotification
         ) => void): this
 
+        /** Emitted when a group participant changes its phone number. */
+        on(event: 'group_participant_changed', listener: (
+            /** GroupNotification with more information about the action */
+            notification: GroupNotification
+        ) => void): this
+
         /** Emitted when media has been uploaded for a message sent by the client */
         on(event: 'media_uploaded', listener: (
             /** The message with media that was uploaded */
@@ -501,6 +507,7 @@ declare namespace WAWebJS {
         GROUP_JOIN = 'group_join',
         GROUP_LEAVE = 'group_leave',
         GROUP_UPDATE = 'group_update',
+        GROUP_PARTICIPANT_CHANGED = 'group_participant_changed',
         QR_RECEIVED = 'qr',
         LOADING_SCREEN = 'loading_screen',
         DISCONNECTED = 'disconnected',

--- a/src/Client.js
+++ b/src/Client.js
@@ -376,6 +376,18 @@ class Client extends EventEmitter {
                 last_message = msg;
             }
 
+            if (msg.type === 'gp2') {
+                const notification = new GroupNotification(this, msg);
+                if (msg.subtype === 'modify') {
+                    /**
+                     * Emitted when a group participant changes its phone number.
+                     * @event Client#group_participant_changed
+                     * @param {GroupNotification} notification GroupNotification with more information about the action
+                     */
+                    this.emit(Events.GROUP_PARTICIPANT_CHANGED, notification);
+                }
+            }
+
         });
 
         await page.exposeFunction('onRemoveMessageEvent', (msg) => {

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -46,6 +46,7 @@ exports.Events = {
     GROUP_JOIN: 'group_join',
     GROUP_LEAVE: 'group_leave',
     GROUP_UPDATE: 'group_update',
+    GROUP_PARTICIPANT_CHANGED: 'group_participant_changed',
     QR_RECEIVED: 'qr',
     LOADING_SCREEN: 'loading_screen',
     DISCONNECTED: 'disconnected',


### PR DESCRIPTION
## Description
PR adds `group_participant_changed` event.
The event is emitted when a participant changes their phone number.
After a user changes their phone number, their id is also going to change.

The notification the event belongs to can be seen **in a group chat**:
1.  In case the contact is in your contact list
![1](https://user-images.githubusercontent.com/93551621/220493611-d2e2a256-25b2-4182-8959-e0dd0bd70e92.png)
2. In case the contact **is not** in your contact list:
![4](https://user-images.githubusercontent.com/93551621/220494031-7d186b10-8f9e-44b0-a960-963b50d8ddf5.png)

## Usage Example
```javascript
client.on('group_participant_changed', (notification) => {
    /** A participantId (an old one) that was changed, e.g.: 'XXXXXXXXX@c.us'. */
    const oldId = notification.author;
    /** A new participantId, e.g.: 'YYYYYYYYY@c.us'. */
    const newId = notification.recipientIds[0];
    /** A groupId where the event was emitted, e.g.: 'ZZZZZZZZZ@g.us. */
    const groupId = notification.chatId;
    /** Date the event was emitted at. */
    const eventTime = (new Date(notification.timestamp * 1000)).toLocaleString();

    console.log(`The user ${oldId} changed their phone number in ${groupId} at ${eventTime}. ` +
        `Their new id is ${newId}.`)
});
```

## Related Issue
#1590

## Types of Changes
- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (index.d.ts).