### PR TITLE
feat: added group_admin_changed event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -192,6 +192,12 @@ declare namespace WAWebJS {
             notification: GroupNotification
         ) => void): this
 
+        /** Emitted when a current user is promoted to an admin or demoted to a regular user */
+        on(event: 'group_admin_change', listener: (
+            /** GroupNotification with more information about the action */
+            notification: GroupNotification
+        ) => void): this
+
         /** Emitted when group settings are updated, such as subject, description or picture */
         on(event: 'group_update', listener: (
             /** GroupNotification with more information about the action */
@@ -500,6 +506,7 @@ declare namespace WAWebJS {
         MEDIA_UPLOADED = 'media_uploaded',
         GROUP_JOIN = 'group_join',
         GROUP_LEAVE = 'group_leave',
+        GROUP_ADMIN_CHANGE = 'group_admin_change',
         GROUP_UPDATE = 'group_update',
         QR_RECEIVED = 'qr',
         LOADING_SCREEN = 'loading_screen',

--- a/index.d.ts
+++ b/index.d.ts
@@ -193,7 +193,7 @@ declare namespace WAWebJS {
         ) => void): this
 
         /** Emitted when a current user is promoted to an admin or demoted to a regular user */
-        on(event: 'group_admin_change', listener: (
+        on(event: 'group_admin_changed', listener: (
             /** GroupNotification with more information about the action */
             notification: GroupNotification
         ) => void): this
@@ -506,7 +506,7 @@ declare namespace WAWebJS {
         MEDIA_UPLOADED = 'media_uploaded',
         GROUP_JOIN = 'group_join',
         GROUP_LEAVE = 'group_leave',
-        GROUP_ADMIN_CHANGE = 'group_admin_change',
+        GROUP_ADMIN_CHANGED = 'group_admin_changed',
         GROUP_UPDATE = 'group_update',
         QR_RECEIVED = 'qr',
         LOADING_SCREEN = 'loading_screen',

--- a/src/Client.js
+++ b/src/Client.js
@@ -317,6 +317,13 @@ class Client extends EventEmitter {
                      * @param {GroupNotification} notification GroupNotification with more information about the action
                      */
                     this.emit(Events.GROUP_LEAVE, notification);
+                } else if (msg.subtype === 'promote' || msg.subtype === 'demote') {
+                    /**
+                     * Emitted when a current user is promoted to an admin or demoted to a regular user.
+                     * @event Client#group_admin_me
+                     * @param {GroupNotification} notification GroupNotification with more information about the action
+                     */
+                    this.emit(Events.GROUP_ADMIN_CHANGE, notification);
                 } else {
                     /**
                      * Emitted when group settings are updated, such as subject, description or picture.

--- a/src/Client.js
+++ b/src/Client.js
@@ -320,10 +320,10 @@ class Client extends EventEmitter {
                 } else if (msg.subtype === 'promote' || msg.subtype === 'demote') {
                     /**
                      * Emitted when a current user is promoted to an admin or demoted to a regular user.
-                     * @event Client#group_admin_me
+                     * @event Client#group_admin_changed
                      * @param {GroupNotification} notification GroupNotification with more information about the action
                      */
-                    this.emit(Events.GROUP_ADMIN_CHANGE, notification);
+                    this.emit(Events.GROUP_ADMIN_CHANGED, notification);
                 } else {
                     /**
                      * Emitted when group settings are updated, such as subject, description or picture.

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -45,6 +45,7 @@ exports.Events = {
     MEDIA_UPLOADED: 'media_uploaded',
     GROUP_JOIN: 'group_join',
     GROUP_LEAVE: 'group_leave',
+    GROUP_ADMIN_CHANGE: 'group_admin_change',
     GROUP_UPDATE: 'group_update',
     QR_RECEIVED: 'qr',
     LOADING_SCREEN: 'loading_screen',

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -45,7 +45,7 @@ exports.Events = {
     MEDIA_UPLOADED: 'media_uploaded',
     GROUP_JOIN: 'group_join',
     GROUP_LEAVE: 'group_leave',
-    GROUP_ADMIN_CHANGE: 'group_admin_change',
+    GROUP_ADMIN_CHANGED: 'group_admin_changed',
     GROUP_UPDATE: 'group_update',
     QR_RECEIVED: 'qr',
     LOADING_SCREEN: 'loading_screen',


### PR DESCRIPTION
## Description
PR adds `group_admin_changed` event.
The event is emitted when a current user is promoted to an admin or demoted to a regular user.

## Usage Example
```javascript
client.on('group_admin_changed', (notification) => {
    if (notification.type === 'promote') {
        /** 
          * Emitted when a current user is promoted to an admin.
          * {@link notification.author} is a user who performs the action of promoting/demoting the current user.
          */
        console.log(`You were promoted by ${notification.author}`);
    } else if (notification.type === 'demote')
        /** Emitted when a current user is demoted to a regular user. */
        console.log(`You were demoted by ${notification.author}`);
});
```

## Related Issue
#1730 

## Types of Changes
- [ ] Dependency change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly (index.d.ts).