### PR TITLE
fix sendMessage for v2.24xx

### DIFF
--- a/src/util/Injected.js
+++ b/src/util/Injected.js
@@ -407,7 +407,7 @@ exports.LoadUtils = () => {
             chat.t = msg.t;
 
             const sendChannelMsgResponse = await window.Store.SendChannelMessage.sendNewsletterMessageJob({
-                msgData: message,
+                msg: msg,
                 type: message.type === 'chat' ? 'text' : isMedia ? 'media' : message.type,
                 newsletterJid: chat.id.toJid(),
                 ...(isMedia ? { mediaMetadata: msg.avParams() } : {})


### PR DESCRIPTION
# PR Details

Fixes sendMessages for Channels

## Description

fixes sendMessages for v2.24xx

since 2.24xx WhatApp changed the underlying sendNewsletterMessageJob which now requires a proper Msg Object to be passed and renamed from msgData to msg.


## Motivation and Context

fix sendMessages

## How Has This Been Tested

tested sending messages including media and other types. 

## Types of changes

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



